### PR TITLE
Skip firmware install for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ endif
 	@depmod -a $(KVER)
 
 	@mkdir -p /lib/firmware/rtl_bt/
-	@cp *.bin /lib/firmware/rtl_bt/.
 
 	@echo "Install btusb/btrtl SUCCESS"
 


### PR DESCRIPTION
This fix `cp: cannot stat '*.bin': No such file or directory` on `make install` since #14 removed all `*.bin` files.