### PR TITLE
Added new RTW8852BE device (Archer TX20E)

### DIFF
--- a/btusb.c
+++ b/btusb.c
@@ -442,6 +442,8 @@ static const struct usb_device_id blacklist_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0bda, 0x887b), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
+	{ USB_DEVICE(0x13d3, 0x3570), .driver_info = BTUSB_REALTEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3571), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
 


### PR DESCRIPTION
Patch for new RTW8852 device (TP-Link Archer TX20E).

I recently bought the adapter, WiFi has been working out of the box  but bluetooth was not even after installing this module. 

Ran lsusb and found out my btdevice id is not even included, hence this patch. 

![Screenshot_20230904_230723](https://github.com/lwfinger/rtw89-BT/assets/50095635/c549b5ff-8c8e-4c51-83c9-052de88ecd3d)

Working fine after I installed the DKMS packaging module.
