### PR TITLE
Syncing upstream bluetooth next changes

### DIFF
--- a/btusb.c
+++ b/btusb.c
@@ -442,6 +442,8 @@ static const struct usb_device_id blacklist_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0bda, 0x887b), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
+	{ USB_DEVICE(0x0bda, 0xb85b), .driver_info = BTUSB_REALTEK |
+							 BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3570), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3571), .driver_info = BTUSB_REALTEK |

--- a/btusb.c
+++ b/btusb.c
@@ -2501,7 +2501,8 @@ static int btusb_mtk_hci_wmt_sync(struct hci_dev *hdev,
 		err = -ETIMEDOUT;
 		goto err_free_wc;
 	}
-
+	if (data->evt_skb == NULL)
+		goto err_free_wc;
 	/* Parse and handle the return WMT event */
 	wmt_evt = (struct btmtk_hci_wmt_evt *)data->evt_skb->data;
 	if (wmt_evt->whdr.op != hdr->op) {


### PR DESCRIPTION
From latest 6.7rc-3 kernel tree on kernel.org.
1. [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.7-rc4&id=da06ff1f585ea784c79f80e7fab0e0c4ebb49c1c](btusb: Add 0bda:b85b for Fn-Link RTL8852BE)
2. [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.7-rc4&id=624820f7c8826dd010e8b1963303c145f99816e9](btusb: Add date->evt_skb is NULL check)