### PR TITLE
Bring repo up to date with kernel 6.9

### DIFF
--- a/btusb.c
+++ b/btusb.c
@@ -4342,11 +4342,6 @@ static int btusb_probe(struct usb_interface *intf,
 	hdev->bus = HCI_USB;
 	hci_set_drvdata(hdev, data);
 
-	if (id->driver_info & BTUSB_AMP)
-		hdev->dev_type = HCI_AMP;
-	else
-		hdev->dev_type = HCI_PRIMARY;
-
 	data->hdev = hdev;
 
 	SET_HCIDEV_DEV(hdev, &intf->dev);
@@ -4839,10 +4834,8 @@ static struct usb_driver btusb_driver = {
 	.disable_hub_initiated_lpm = 1,
 
 #ifdef CONFIG_DEV_COREDUMP
-	.drvwrap = {
-		.driver = {
-			.coredump = btusb_coredump,
-		},
+	.driver = {
+		.coredump = btusb_coredump,
 	},
 #endif
 };


### PR DESCRIPTION
The driver now builds successfully for 6.9.4

This applies changes made to upstream in:
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/bluetooth/btusb.c?id=84a4bb6548a29326564f0e659fb8064503ecc1c7
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/bluetooth/btusb.c?id=49a78b05d5ca1e23fd737747a8757b8bdc319b30